### PR TITLE
Prevent the situation that the malformed entries might crash the process

### DIFF
--- a/DataPresentation/lass_pm25_to_thingspeak.py
+++ b/DataPresentation/lass_pm25_to_thingspeak.py
@@ -64,17 +64,14 @@ def on_connect(client, userdata, flags, rc):
 def on_message(client, userdata, msg):
     #print("mqtt payload=%s" %(msg.payload))
     items = re.split('\|',str(msg.payload))
-    flag = 0
     for item in items:
         if item == '':
             continue 
         pairs = re.split('=',item)
         if (len(items)==1):
             continue
-        flag = 1
         if (pairs[0] == "device_id"):
-            if (pairs[1] != LASS_DEVICE_ID):
-                return
+            value_devId = pairs[1]
         elif (pairs[0] == "s_d0"):
             value_dust = pairs[1]
         elif (pairs[0] == "s_t0"):
@@ -83,26 +80,33 @@ def on_message(client, userdata, msg):
             value_humidity = pairs[1]
         elif (pairs[0] == "s_1"):
             value_battery = pairs[1]
-    if (flag==0):
-        return
-    params = urllib.urlencode({'field1': value_dust, 'field2': value_temperature, 
+
+    try:
+        if (value_devId == LASS_DEVICE_ID):
+            #print "Got the data from %s" % LASS_DEVICE_ID
+            params = urllib.urlencode({'field1': value_dust, 'field2': value_temperature, 
                                'field3': value_humidity, 'field4': value_battery, 
                                'key': ThingSpeak_API})
-    headers = {"Content-type": "application/x-www-form-urlencoded","Accept": "text/plain"}
+            post_to_thingspeak(params)
+    except:
+         return
 
+# Post the data to ThingSpeak
+def post_to_thingspeak(payload):
+    headers = {"Content-type": "application/x-www-form-urlencoded","Accept": "text/plain"}
     not_connected = 1
     while (not_connected):
-      try:
-        conn = httplib.HTTPConnection("api.thingspeak.com:80")
-        conn.connect()
-        not_connected = 0
-      except (httplib.HTTPException, socket.error) as ex:
-        print "Error: %s" % ex
-        time.sleep(10)  # sleep 10 seconds
+        try:
+            conn = httplib.HTTPConnection("api.thingspeak.com:80")
+            conn.connect()
+            not_connected = 0
+        except (httplib.HTTPException, socket.error) as ex:
+            print "Error: %s" % ex
+            time.sleep(10)  # sleep 10 seconds
 
-    conn.request("POST", "/update", params, headers)
+    conn.request("POST", "/update", payload, headers)
     response = conn.getresponse()
-    print( response.status, response.reason, params, time.strftime("%c"))
+    print( response.status, response.reason, payload, time.strftime("%c"))
     data = response.read()
     conn.close()
 


### PR DESCRIPTION
There is a malformed entries being occurred recently on LASS server. The content is like this:

```
mqtt payload=|ver_format=3|fmt_opt=1|app=WEBDUINO_COPY|date=2016-04-28|time=05:17:07|PM10=6340|PM2_5=2450|SiteName='Null'|SiteID=wa4268|gps_lat=0|gps_lon=0
```

It crashed the process at the line of `urllib.urlencode()`.
IMHO, making it take care the interested MQTT entries only could solve it all.

To make it earlier to customize, I also separated the POST part logic out from `on_message()`.
